### PR TITLE
fix: recover panicking tools, introduce RunConfig, add ToolCallID

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -9,16 +9,28 @@ import (
 	tool "github.com/benaskins/axon-tool"
 )
 
+// Role represents the sender of a message.
+type Role string
+
+const (
+	RoleSystem    Role = "system"
+	RoleUser      Role = "user"
+	RoleAssistant Role = "assistant"
+	RoleTool      Role = "tool"
+)
+
 // Message represents a single message in a conversation.
 type Message struct {
-	Role      string
-	Content   string
-	Thinking  string
-	ToolCalls []ToolCall
+	Role       Role
+	Content    string
+	Thinking   string
+	ToolCalls  []ToolCall
+	ToolCallID string // Correlates a tool result with its originating ToolCall.
 }
 
 // ToolCall represents an LLM's decision to invoke a tool.
 type ToolCall struct {
+	ID        string // Provider-assigned correlation ID (e.g. OpenAI tool_call_id).
 	Name      string
 	Arguments map[string]any
 }

--- a/agent_test.go
+++ b/agent_test.go
@@ -9,22 +9,25 @@ import (
 
 func TestMessageFields(t *testing.T) {
 	msg := loop.Message{
-		Role:    "assistant",
+		Role:    loop.RoleAssistant,
 		Content: "Hello!",
 		Thinking: "Let me think...",
 		ToolCalls: []loop.ToolCall{
-			{Name: "web_search", Arguments: map[string]any{"query": "go"}},
+			{ID: "call_1", Name: "web_search", Arguments: map[string]any{"query": "go"}},
 		},
 	}
 
-	if msg.Role != "assistant" {
-		t.Errorf("Role = %q, want %q", msg.Role, "assistant")
+	if msg.Role != loop.RoleAssistant {
+		t.Errorf("Role = %q, want %q", msg.Role, loop.RoleAssistant)
 	}
 	if len(msg.ToolCalls) != 1 {
 		t.Fatalf("got %d tool calls, want 1", len(msg.ToolCalls))
 	}
 	if msg.ToolCalls[0].Name != "web_search" {
 		t.Errorf("ToolCall name = %q, want %q", msg.ToolCalls[0].Name, "web_search")
+	}
+	if msg.ToolCalls[0].ID != "call_1" {
+		t.Errorf("ToolCall ID = %q, want %q", msg.ToolCalls[0].ID, "call_1")
 	}
 	if msg.ToolCalls[0].Arguments["query"] != "go" {
 		t.Errorf("ToolCall query = %v, want %q", msg.ToolCalls[0].Arguments["query"], "go")
@@ -35,7 +38,7 @@ func TestRequestFields(t *testing.T) {
 	req := loop.Request{
 		Model: "llama3",
 		Messages: []loop.Message{
-			{Role: "user", Content: "Hi"},
+			{Role: loop.RoleUser, Content: "Hi"},
 		},
 		Stream: true,
 		Options: map[string]any{"temperature": 0.7},
@@ -58,7 +61,7 @@ func TestResponseFields(t *testing.T) {
 		Thinking: "Processing...",
 		Done:     true,
 		ToolCalls: []loop.ToolCall{
-			{Name: "current_time", Arguments: map[string]any{}},
+			{ID: "call_42", Name: "current_time", Arguments: map[string]any{}},
 		},
 	}
 
@@ -67,6 +70,26 @@ func TestResponseFields(t *testing.T) {
 	}
 	if resp.Content != "Here you go" {
 		t.Errorf("Content = %q, want %q", resp.Content, "Here you go")
+	}
+	if resp.ToolCalls[0].ID != "call_42" {
+		t.Errorf("ToolCall ID = %q, want %q", resp.ToolCalls[0].ID, "call_42")
+	}
+}
+
+func TestRoleConstants(t *testing.T) {
+	tests := []struct {
+		role loop.Role
+		want string
+	}{
+		{loop.RoleSystem, "system"},
+		{loop.RoleUser, "user"},
+		{loop.RoleAssistant, "assistant"},
+		{loop.RoleTool, "tool"},
+	}
+	for _, tt := range tests {
+		if string(tt.role) != tt.want {
+			t.Errorf("Role = %q, want %q", tt.role, tt.want)
+		}
 	}
 }
 
@@ -97,7 +120,7 @@ func TestLLMClientInterface(t *testing.T) {
 
 	err := c.Chat(context.Background(), &loop.Request{
 		Model:    "test",
-		Messages: []loop.Message{{Role: "user", Content: "Hi"}},
+		Messages: []loop.Message{{Role: loop.RoleUser, Content: "Hi"}},
 	}, func(resp loop.Response) error {
 		collected += resp.Content
 		return nil

--- a/example/main.go
+++ b/example/main.go
@@ -44,17 +44,22 @@ func main() {
 	req := &loop.Request{
 		Model: "llama3",
 		Messages: []loop.Message{
-			{Role: "system", Content: "You are a helpful assistant. Use tools when appropriate."},
-			{Role: "user", Content: "Please greet Alice."},
+			{Role: loop.RoleSystem, Content: "You are a helpful assistant. Use tools when appropriate."},
+			{Role: loop.RoleUser, Content: "Please greet Alice."},
 		},
 		Stream: true,
 	}
 
 	// 4. Run the loop with streaming callbacks.
-	result, err := loop.Run(ctx, client, req, tools, nil, loop.Callbacks{
-		OnToken:   func(t string) { fmt.Print(t) },
-		OnToolUse: func(name string, args map[string]any) { fmt.Printf("\n[tool] %s %v\n", name, args) },
-		OnDone:    func(ms int64) { fmt.Printf("\n[done in %dms]\n", ms) },
+	result, err := loop.Run(ctx, loop.RunConfig{
+		Client:  client,
+		Request: req,
+		Tools:   tools,
+		Callbacks: loop.Callbacks{
+			OnToken:   func(t string) { fmt.Print(t) },
+			OnToolUse: func(name string, args map[string]any) { fmt.Printf("\n[tool] %s %v\n", name, args) },
+			OnDone:    func(ms int64) { fmt.Printf("\n[done in %dms]\n", ms) },
+		},
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/run.go
+++ b/run.go
@@ -26,12 +26,27 @@ type Result struct {
 	Thinking string
 }
 
+// RunConfig bundles parameters for Run, keeping the function signature small.
+type RunConfig struct {
+	Client  LLMClient
+	Request *Request
+	Tools   map[string]tool.ToolDef
+	ToolCtx *tool.ToolContext
+	Callbacks
+}
+
 // Run executes a conversation loop: sends messages to the LLM, streams
 // the response, executes tool calls, and repeats until no more tool
 // calls are made.
 //
 // tools and toolCtx may be nil for simple chat without tool support.
-func Run(ctx context.Context, client LLMClient, req *Request, tools map[string]tool.ToolDef, toolCtx *tool.ToolContext, cb Callbacks) (*Result, error) {
+func Run(ctx context.Context, cfg RunConfig) (*Result, error) {
+	client := cfg.Client
+	req := cfg.Request
+	tools := cfg.Tools
+	toolCtx := cfg.ToolCtx
+	cb := cfg.Callbacks
+
 	start := time.Now()
 	messages := make([]Message, len(req.Messages))
 	copy(messages, req.Messages)
@@ -107,23 +122,21 @@ func Run(ctx context.Context, client LLMClient, req *Request, tools map[string]t
 		content := turnContent.String()
 		thinking := turnThinking.String()
 
-		// If tool calls, don't count tool-call content as final output
-		if len(toolCalls) > 0 {
-			content = ""
-		}
-
-		finalContent.WriteString(content)
 		finalThinking.WriteString(thinking)
 
 		// No tool calls — conversation turn is complete
 		if len(toolCalls) == 0 {
+			finalContent.WriteString(content)
 			break
 		}
 
+		// Preserve LLM explanations alongside tool calls
+		finalContent.WriteString(content)
+
 		// Append assistant message with tool calls to history
 		messages = append(messages, Message{
-			Role:      "assistant",
-			Content:   turnContent.String(),
+			Role:      RoleAssistant,
+			Content:   content,
 			Thinking:  thinking,
 			ToolCalls: toolCalls,
 		})
@@ -135,16 +148,18 @@ func Run(ctx context.Context, client LLMClient, req *Request, tools map[string]t
 			}
 
 			if def, ok := tools[tc.Name]; ok {
-				result := def.Execute(toolCtx, tc.Arguments)
+				result := executeTool(def, toolCtx, tc.Arguments)
 				messages = append(messages, Message{
-					Role:    "tool",
-					Content: result.Content,
+					Role:       RoleTool,
+					Content:    result,
+					ToolCallID: tc.ID,
 				})
 			} else {
 				slog.Warn("unknown tool called", "tool", tc.Name)
 				messages = append(messages, Message{
-					Role:    "tool",
-					Content: fmt.Sprintf("Error: unknown tool %q", tc.Name),
+					Role:       RoleTool,
+					Content:    fmt.Sprintf("Error: unknown tool %q", tc.Name),
+					ToolCallID: tc.ID,
 				})
 			}
 		}
@@ -159,4 +174,17 @@ func Run(ctx context.Context, client LLMClient, req *Request, tools map[string]t
 		Content:  finalContent.String(),
 		Thinking: finalThinking.String(),
 	}, nil
+}
+
+// executeTool runs a tool's Execute function with panic recovery so that a
+// misbehaving tool cannot crash the entire loop.
+func executeTool(def tool.ToolDef, toolCtx *tool.ToolContext, args map[string]any) (content string) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("tool panicked", "tool", def.Name, "panic", r)
+			content = fmt.Sprintf("Error: tool %q panicked: %v", def.Name, r)
+		}
+	}()
+	result := def.Execute(toolCtx, args)
+	return result.Content
 }

--- a/run_test.go
+++ b/run_test.go
@@ -20,15 +20,19 @@ func TestRunSimpleChat(t *testing.T) {
 	var tokens []string
 	var doneCalled bool
 
-	result, err := loop.Run(context.Background(), client, &loop.Request{
-		Model:    "test-model",
-		Messages: []loop.Message{{Role: "user", Content: "Hi"}},
-	}, nil, nil, loop.Callbacks{
-		OnToken: func(token string) {
-			tokens = append(tokens, token)
+	result, err := loop.Run(context.Background(), loop.RunConfig{
+		Client: client,
+		Request: &loop.Request{
+			Model:    "test-model",
+			Messages: []loop.Message{{Role: loop.RoleUser, Content: "Hi"}},
 		},
-		OnDone: func(durationMs int64) {
-			doneCalled = true
+		Callbacks: loop.Callbacks{
+			OnToken: func(token string) {
+				tokens = append(tokens, token)
+			},
+			OnDone: func(durationMs int64) {
+				doneCalled = true
+			},
 		},
 	})
 
@@ -55,7 +59,7 @@ func TestRunWithToolCall(t *testing.T) {
 				{
 					Content: "",
 					ToolCalls: []loop.ToolCall{
-						{Name: "current_time", Arguments: map[string]any{}},
+						{ID: "call_1", Name: "current_time", Arguments: map[string]any{}},
 					},
 					Done: true,
 				},
@@ -78,12 +82,18 @@ func TestRunWithToolCall(t *testing.T) {
 	}
 
 	var toolUses []string
-	result, err := loop.Run(context.Background(), client, &loop.Request{
-		Model:    "test-model",
-		Messages: []loop.Message{{Role: "user", Content: "What time is it?"}},
-	}, tools, &tool.ToolContext{Ctx: context.Background()}, loop.Callbacks{
-		OnToolUse: func(name string, args map[string]any) {
-			toolUses = append(toolUses, name)
+	result, err := loop.Run(context.Background(), loop.RunConfig{
+		Client: client,
+		Request: &loop.Request{
+			Model:    "test-model",
+			Messages: []loop.Message{{Role: loop.RoleUser, Content: "What time is it?"}},
+		},
+		Tools:   tools,
+		ToolCtx: &tool.ToolContext{Ctx: context.Background()},
+		Callbacks: loop.Callbacks{
+			OnToolUse: func(name string, args map[string]any) {
+				toolUses = append(toolUses, name)
+			},
 		},
 	})
 
@@ -108,10 +118,13 @@ func TestRunNoTools(t *testing.T) {
 		},
 	}
 
-	result, err := loop.Run(context.Background(), client, &loop.Request{
-		Model:    "test-model",
-		Messages: []loop.Message{{Role: "user", Content: "Hello"}},
-	}, nil, nil, loop.Callbacks{})
+	result, err := loop.Run(context.Background(), loop.RunConfig{
+		Client: client,
+		Request: &loop.Request{
+			Model:    "test-model",
+			Messages: []loop.Message{{Role: loop.RoleUser, Content: "Hello"}},
+		},
+	})
 
 	if err != nil {
 		t.Fatal(err)
@@ -130,12 +143,16 @@ func TestRunWithThinking(t *testing.T) {
 	}
 
 	var thinkingTokens []string
-	result, err := loop.Run(context.Background(), client, &loop.Request{
-		Model:    "test-model",
-		Messages: []loop.Message{{Role: "user", Content: "Think about this"}},
-	}, nil, nil, loop.Callbacks{
-		OnThinking: func(token string) {
-			thinkingTokens = append(thinkingTokens, token)
+	result, err := loop.Run(context.Background(), loop.RunConfig{
+		Client: client,
+		Request: &loop.Request{
+			Model:    "test-model",
+			Messages: []loop.Message{{Role: loop.RoleUser, Content: "Think about this"}},
+		},
+		Callbacks: loop.Callbacks{
+			OnThinking: func(token string) {
+				thinkingTokens = append(thinkingTokens, token)
+			},
 		},
 	})
 
@@ -165,10 +182,15 @@ func TestRunPassesToolsToClient(t *testing.T) {
 		"current_time": tool.CurrentTimeTool(),
 	}
 
-	_, err := loop.Run(context.Background(), client, &loop.Request{
-		Model:    "test",
-		Messages: []loop.Message{{Role: "user", Content: "time?"}},
-	}, tools, &tool.ToolContext{Ctx: context.Background()}, loop.Callbacks{})
+	_, err := loop.Run(context.Background(), loop.RunConfig{
+		Client: client,
+		Request: &loop.Request{
+			Model:    "test",
+			Messages: []loop.Message{{Role: loop.RoleUser, Content: "time?"}},
+		},
+		Tools:   tools,
+		ToolCtx: &tool.ToolContext{Ctx: context.Background()},
+	})
 
 	if err != nil {
 		t.Fatal(err)
@@ -212,11 +234,16 @@ func TestRunMaxIterationsExceeded(t *testing.T) {
 		},
 	}
 
-	_, err := loop.Run(context.Background(), client, &loop.Request{
-		Model:         "test",
-		Messages:      []loop.Message{{Role: "user", Content: "loop"}},
-		MaxIterations: 3,
-	}, tools, &tool.ToolContext{Ctx: context.Background()}, loop.Callbacks{})
+	_, err := loop.Run(context.Background(), loop.RunConfig{
+		Client: client,
+		Request: &loop.Request{
+			Model:         "test",
+			Messages:      []loop.Message{{Role: loop.RoleUser, Content: "loop"}},
+			MaxIterations: 3,
+		},
+		Tools:   tools,
+		ToolCtx: &tool.ToolContext{Ctx: context.Background()},
+	})
 
 	if err == nil {
 		t.Fatal("expected error for max iterations exceeded, got nil")
@@ -233,7 +260,7 @@ func TestRunUnknownToolCall(t *testing.T) {
 			{
 				{
 					ToolCalls: []loop.ToolCall{
-						{Name: "nonexistent_tool", Arguments: map[string]any{}},
+						{ID: "call_1", Name: "nonexistent_tool", Arguments: map[string]any{}},
 					},
 					Done: true,
 				},
@@ -254,10 +281,15 @@ func TestRunUnknownToolCall(t *testing.T) {
 		},
 	}
 
-	result, err := loop.Run(context.Background(), client, &loop.Request{
-		Model:    "test",
-		Messages: []loop.Message{{Role: "user", Content: "call something"}},
-	}, tools, &tool.ToolContext{Ctx: context.Background()}, loop.Callbacks{})
+	result, err := loop.Run(context.Background(), loop.RunConfig{
+		Client: client,
+		Request: &loop.Request{
+			Model:    "test",
+			Messages: []loop.Message{{Role: loop.RoleUser, Content: "call something"}},
+		},
+		Tools:   tools,
+		ToolCtx: &tool.ToolContext{Ctx: context.Background()},
+	})
 
 	if err != nil {
 		t.Fatal(err)
@@ -270,16 +302,215 @@ func TestRunUnknownToolCall(t *testing.T) {
 func TestRunChatClientError(t *testing.T) {
 	client := &errorClient{err: fmt.Errorf("connection refused")}
 
-	_, err := loop.Run(context.Background(), client, &loop.Request{
-		Model:    "test",
-		Messages: []loop.Message{{Role: "user", Content: "Hi"}},
-	}, nil, nil, loop.Callbacks{})
+	_, err := loop.Run(context.Background(), loop.RunConfig{
+		Client: client,
+		Request: &loop.Request{
+			Model:    "test",
+			Messages: []loop.Message{{Role: loop.RoleUser, Content: "Hi"}},
+		},
+	})
 
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
 	if !strings.Contains(err.Error(), "connection refused") {
 		t.Errorf("error = %q, want it to contain 'connection refused'", err.Error())
+	}
+}
+
+func TestRunPanickingToolRecovery(t *testing.T) {
+	client := &multiTurnClient{
+		turns: [][]loop.Response{
+			// First turn: model calls a tool that panics
+			{
+				{
+					ToolCalls: []loop.ToolCall{
+						{ID: "call_1", Name: "bad_tool", Arguments: map[string]any{}},
+					},
+					Done: true,
+				},
+			},
+			// Second turn: model responds after seeing panic error
+			{
+				{Content: "The tool failed.", Done: true},
+			},
+		},
+	}
+
+	tools := map[string]tool.ToolDef{
+		"bad_tool": {
+			Name: "bad_tool",
+			Execute: func(ctx *tool.ToolContext, args map[string]any) tool.ToolResult {
+				panic("segfault simulation")
+			},
+		},
+	}
+
+	result, err := loop.Run(context.Background(), loop.RunConfig{
+		Client: client,
+		Request: &loop.Request{
+			Model:    "test",
+			Messages: []loop.Message{{Role: loop.RoleUser, Content: "use the bad tool"}},
+		},
+		Tools:   tools,
+		ToolCtx: &tool.ToolContext{Ctx: context.Background()},
+	})
+
+	if err != nil {
+		t.Fatalf("Run should not fail when a tool panics, got: %v", err)
+	}
+	if result.Content != "The tool failed." {
+		t.Errorf("Content = %q, want %q", result.Content, "The tool failed.")
+	}
+}
+
+func TestRunToolCallIDPropagation(t *testing.T) {
+	var capturedMessages []loop.Message
+	client := &multiTurnClient{
+		turns: [][]loop.Response{
+			{
+				{
+					ToolCalls: []loop.ToolCall{
+						{ID: "call_abc123", Name: "echo", Arguments: map[string]any{"text": "hi"}},
+					},
+					Done: true,
+				},
+			},
+			{
+				{Content: "Done.", Done: true},
+			},
+		},
+	}
+
+	// Use a spy to capture the messages sent on the second turn
+	origChat := client.Chat
+	client2 := &spyClient{
+		onChat: func(req *loop.Request) {
+			capturedMessages = req.Messages
+		},
+	}
+	// Wrap: first turn from multiTurnClient, spy captures second turn
+	wrapper := &delegatingClient{
+		clients: []loop.LLMClient{client, client2},
+	}
+	_ = origChat // suppress unused
+
+	tools := map[string]tool.ToolDef{
+		"echo": {
+			Name: "echo",
+			Execute: func(ctx *tool.ToolContext, args map[string]any) tool.ToolResult {
+				return tool.ToolResult{Content: "echoed"}
+			},
+		},
+	}
+
+	_, _ = loop.Run(context.Background(), loop.RunConfig{
+		Client: wrapper,
+		Request: &loop.Request{
+			Model:    "test",
+			Messages: []loop.Message{{Role: loop.RoleUser, Content: "echo something"}},
+		},
+		Tools:   tools,
+		ToolCtx: &tool.ToolContext{Ctx: context.Background()},
+	})
+
+	// Find the tool result message in captured messages
+	var found bool
+	for _, msg := range capturedMessages {
+		if msg.Role == loop.RoleTool {
+			found = true
+			if msg.ToolCallID != "call_abc123" {
+				t.Errorf("ToolCallID = %q, want %q", msg.ToolCallID, "call_abc123")
+			}
+		}
+	}
+	if !found {
+		t.Error("no tool result message found in captured messages")
+	}
+}
+
+func TestRunContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	client := &cancellingClient{
+		cancel: cancel,
+	}
+
+	_, err := loop.Run(ctx, loop.RunConfig{
+		Client: client,
+		Request: &loop.Request{
+			Model:    "test",
+			Messages: []loop.Message{{Role: loop.RoleUser, Content: "Hi"}},
+		},
+	})
+
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+	if !strings.Contains(err.Error(), "context canceled") {
+		t.Errorf("error = %q, want it to contain 'context canceled'", err.Error())
+	}
+}
+
+func TestRunMultiToolCallsInSingleTurn(t *testing.T) {
+	var toolOrder []string
+	client := &multiTurnClient{
+		turns: [][]loop.Response{
+			// Model calls two tools in one turn
+			{
+				{
+					ToolCalls: []loop.ToolCall{
+						{ID: "call_1", Name: "tool_a", Arguments: map[string]any{}},
+						{ID: "call_2", Name: "tool_b", Arguments: map[string]any{}},
+					},
+					Done: true,
+				},
+			},
+			// Final answer
+			{
+				{Content: "Both done.", Done: true},
+			},
+		},
+	}
+
+	tools := map[string]tool.ToolDef{
+		"tool_a": {
+			Name: "tool_a",
+			Execute: func(ctx *tool.ToolContext, args map[string]any) tool.ToolResult {
+				toolOrder = append(toolOrder, "a")
+				return tool.ToolResult{Content: "result_a"}
+			},
+		},
+		"tool_b": {
+			Name: "tool_b",
+			Execute: func(ctx *tool.ToolContext, args map[string]any) tool.ToolResult {
+				toolOrder = append(toolOrder, "b")
+				return tool.ToolResult{Content: "result_b"}
+			},
+		},
+	}
+
+	result, err := loop.Run(context.Background(), loop.RunConfig{
+		Client: client,
+		Request: &loop.Request{
+			Model:    "test",
+			Messages: []loop.Message{{Role: loop.RoleUser, Content: "use both tools"}},
+		},
+		Tools:   tools,
+		ToolCtx: &tool.ToolContext{Ctx: context.Background()},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Content != "Both done." {
+		t.Errorf("Content = %q, want %q", result.Content, "Both done.")
+	}
+	if len(toolOrder) != 2 {
+		t.Fatalf("expected 2 tool calls, got %d", len(toolOrder))
+	}
+	if toolOrder[0] != "a" || toolOrder[1] != "b" {
+		t.Errorf("tool execution order = %v, want [a b]", toolOrder)
 	}
 }
 
@@ -322,4 +553,29 @@ func (m *multiTurnClient) Chat(ctx context.Context, req *loop.Request, fn func(l
 		}
 	}
 	return nil
+}
+
+// cancellingClient cancels the context during Chat, simulating mid-loop cancellation.
+type cancellingClient struct {
+	cancel context.CancelFunc
+}
+
+func (c *cancellingClient) Chat(ctx context.Context, req *loop.Request, fn func(loop.Response) error) error {
+	c.cancel()
+	return ctx.Err()
+}
+
+// delegatingClient delegates to a sequence of clients, one per call.
+type delegatingClient struct {
+	clients []loop.LLMClient
+	call    int
+}
+
+func (d *delegatingClient) Chat(ctx context.Context, req *loop.Request, fn func(loop.Response) error) error {
+	if d.call >= len(d.clients) {
+		return nil
+	}
+	c := d.clients[d.call]
+	d.call++
+	return c.Chat(ctx, req, fn)
 }


### PR DESCRIPTION
## Summary

- **Panic recovery**: Wraps `def.Execute` in a deferred `recover()` so a panicking tool returns an error message to the LLM instead of crashing the loop
- **RunConfig struct**: Replaces `Run`'s 7-parameter signature with a single `RunConfig` struct for cleaner call sites
- **ToolCallID**: Adds `ID` field to `ToolCall` and `ToolCallID` to `Message`, propagated through tool result messages for non-Ollama providers (OpenAI, Anthropic) that require correlation IDs
- **Typed Role**: Introduces `Role` type with constants (`RoleSystem`, `RoleUser`, `RoleAssistant`, `RoleTool`) replacing untyped strings
- **Preserved content on tool-call turns**: LLM explanations alongside tool calls are no longer discarded from `Result.Content`

## Test plan

- [x] `TestRunPanickingToolRecovery` — verifies loop continues after a tool panics
- [x] `TestRunToolCallIDPropagation` — verifies ToolCallID flows from ToolCall to tool result Message
- [x] `TestRunContextCancellation` — verifies cancellation mid-loop returns error
- [x] `TestRunMultiToolCallsInSingleTurn` — verifies multiple tools execute in order within one turn
- [x] `TestRoleConstants` — verifies Role type string values
- [x] All 17 existing and new tests pass: `go test ./...`

Fixes #1