### PR TITLE
infra: bump Go to 1.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/benaskins/axon-loop
 
-go 1.26.0
+go 1.26.1
 
 require github.com/benaskins/axon-tool v0.1.0
 


### PR DESCRIPTION
Fixes govulncheck failures from 4 Go stdlib vulnerabilities (GO-2026-4599, GO-2026-4600, GO-2026-4601, GO-2026-4602) fixed in go1.26.1.